### PR TITLE
Try to fix Qt 5.9 support

### DIFF
--- a/hwcomposer/hwcomposer_backend.h
+++ b/hwcomposer/hwcomposer_backend.h
@@ -64,7 +64,7 @@ class QEglFSWindow;
 // Evaluate "x", if it isn't NULL, print a warning
 #define HWC_PLUGIN_EXPECT_NULL(x) \
     { void *res; if ((res = (x)) != NULL) \
-        qWarning("QPA-HWC: %s in %s returned %x", (#x), __func__, (unsigned int)res); }
+        qWarning("QPA-HWC: %s in %s returned %x", (#x), __func__, (intptr_t)res); }
 
 // Evaluate "x", if it is NULL, exit with a fatal error
 #define HWC_PLUGIN_FATAL(x) \
@@ -73,7 +73,7 @@ class QEglFSWindow;
 // Evaluate "x", if it is NULL, exit with a fatal error
 #define HWC_PLUGIN_ASSERT_NOT_NULL(x) \
     { void *res; if ((res = (x)) == NULL) \
-        qFatal("QPA-HWC: %s in %s returned %x", (#x), __func__, (unsigned int)res); }
+        qFatal("QPA-HWC: %s in %s returned %x", (#x), __func__, (intptr_t)res); }
 
 // Evaluate "x", if it doesn't return zero, exit with a fatal error
 #define HWC_PLUGIN_ASSERT_ZERO(x) \

--- a/hwcomposer/hwcomposer_context.cpp
+++ b/hwcomposer/hwcomposer_context.cpp
@@ -137,6 +137,7 @@ QSurfaceFormat HwComposerContext::surfaceFormatFor(const QSurfaceFormat &inputFo
         newFormat.setGreenBufferSize(8);
         newFormat.setBlueBufferSize(8);
     }
+    newFormat.setRenderableType(QSurfaceFormat::OpenGLES);
 
     return newFormat;
 }

--- a/hwcomposer/qeglfsbackingstore.h
+++ b/hwcomposer/qeglfsbackingstore.h
@@ -52,6 +52,7 @@ QT_BEGIN_NAMESPACE
 class QOpenGLContext;
 class QOpenGLPaintDevice;
 class QOpenGLShaderProgram;
+class QOpenGLFunctions;
 
 class QEglFSBackingStore : public QPlatformBackingStore
 {
@@ -71,6 +72,7 @@ private:
     void makeCurrent();
 
     QOpenGLContext *m_context;
+    QOpenGLFunctions *m_funcs;
     QImage m_image;
     uint m_texture;
     QRegion m_dirty;


### PR DESCRIPTION
glEnableVertexAttribArray and glDisableVertexAttribArray, used in QEglFSBackingStore, seem to be not exposed anymore if Qt 5.9 was built with desktop OpenGL support (default on Arch Linux ARM and probably other distros).

QOpenGLFunctions class provides dynamic resolution of OpenGL ES 2.0 functions, so use it instead of calling the functions directly.